### PR TITLE
feat:52 to implement CORS

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
     "main/models"
     "main/utils"
     "main/config"
+    "main/router"
+    "net/http"
     "fmt"
     "log"
     )
@@ -17,14 +19,18 @@ func main(){
         log.Fatalln(err)
     }
     
-    //LOｇの設定
+    //Loｇの設定
     utils.LoggingSettings(conf.Logfile)
     
-    //ＤＢイニシャライズ
+    //DBイニシャライズ
     models.InitDB(conf)
     fmt.Println(models.DB)
     
+    handler := router.CORSMiddleware(router.InitRouters())
+    http.ListenAndServe(":8080", handler)
     
+    
+     /*     
     user1, err := models.GetUser(1)
     if err != nil{
         log.Fatalln(err)
@@ -34,7 +40,7 @@ func main(){
         log.Fatalln(err)
     }
     
-    /*
+
     todos, err := user1.GetTodos()
     if err != nil{
         log.Fatalln(err)
@@ -43,7 +49,6 @@ func main(){
     for _, v :=range todos{
         fmt.Println(v)
     }
-    */
     
     todo1, err := models.GetTodo(1)
     if err != nil{
@@ -55,7 +60,7 @@ func main(){
     if err != nil{
         log.Fatalln(err)
     }
-    /*   
+ 
     u := &models.User{}
     u.Name = "testman"
     u.Email = "testman@exsample.com"

--- a/router/cors.go
+++ b/router/cors.go
@@ -1,0 +1,25 @@
+package router
+
+import("net/http")
+
+func CORSMiddleware(next http.Handler) http.Handler{
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+        // どのオリジンからのアクセスを許可するか
+        w.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
+        // どのHTTPメソッドを許可するか
+        w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+        // どんなヘッダーを許可するか
+        w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+        
+        // プリフライトリクエスト（OPTIONS）への特別な対応
+        if r.Method=="OPTIONS"{
+            w.WriteHeader(http.StatusOK)
+            return
+        }
+
+        // 通常のリクエストは次のハンドラへ
+        next.ServeHTTP(w, r)
+    })
+}
+
+

--- a/router/router.go
+++ b/router/router.go
@@ -5,9 +5,11 @@ import (
     "main/handlers"
     )
 
-func InitRouters(){
-    http.HandleFunc("/api/v1/todos", handlers.TodosHandler) //GET,POSTメソッド
-    http.HandleFunc("/api/v1/todos/", handlers.TodoHandler) //GET,PUSH,DELETEメソッド
-    http.HandleFunc("/api/v1/users", handlers.UsersHandler) //GET,POSTメソッド
-    http.HandleFunc("/api/v1/users/", handlers.UserHandler) //GET,UPDATE.DELETEメソッド
+func InitRouters() http.Handler {
+    mux := http.NewServeMux()       //新しくマルチプレクサを作成
+    mux.HandleFunc("/api/v1/todos", handlers.TodosHandler) //GET,POSTメソッド
+    mux.HandleFunc("/api/v1/todos/", handlers.TodoHandler) //GET,PUSH,DELETEメソッド
+    mux.HandleFunc("/api/v1/users", handlers.UsersHandler) //GET,POSTメソッド
+    mux.HandleFunc("/api/v1/users/", handlers.UserHandler) //GET,UPDATE.DELETEメソッド
+    return mux
 }


### PR DESCRIPTION
# このCORS対応は以下の責任を持たせている
## ①main,goについて
　 handler := router.CORSMiddleware(router.InitRouters())
    http.ListenAndServe(":8080", handler)
↑のように定義し、handlerを作成するときは、InitRouters関数をCORSMiddlewareでラップしたものが作成されようように定義

## ②cors.goについて
　引数で渡されたhandlerに、
　どのオリジンからのアクセスを許容するのか　や　どのHTTPメソッドを許容するかというルールを追加し返却する

## ③router.goについて
①でCORSMiddlewareを呼ぶときに引数にセットされるInitRouters()を定義する（このInitRouters()はハンドラーを返却する）
http.NewServeMux()するのは、もしコード内で http.HandleFunc を使っていて InitRouters が新しい mux を返さない（あるいは DefaultServeMux を返さない）と、DefaultServeMux に登録したハンドラは新しい mux に含まれないため