### PR TITLE
chore: Switch environment variable management from ini file to .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 log.text
 config.ini
+.env
+docker-compose.yml

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -1,39 +1,25 @@
 package config
 
 import(
-    "fmt"
-    "github.com/go-ini/ini"
-    "runtime"
-    "path/filepath"
+    "os"
     )
 
 
-type Config struct{
-    Logfile string
-    User string
+type Config struct {
+    Logfile  string
+    User     string
     Password string
-    DBname string
-}
-
-func getProjectRoot()string{
-    _, filename, _, _ := runtime.Caller(0)
-    return filepath.Dir(filepath.Dir(filename))
+    DBname   string
+    Host     string
 }
 
 
-func LoadConfig(section string)(*Config, error){
-    root:= getProjectRoot()
-    cfgpath:= filepath.Join(root,"config.ini")
-    cfg, err := ini.Load(cfgpath)
-    
-    if err != nil{
-        return nil, fmt.Errorf("iniファイル読込エラー：%w", err)
+func LoadConfig() *Config {
+    return &Config{
+        Logfile:  os.Getenv("LOGFILE"),
+        User:     os.Getenv("DB_USER"),
+        Password: os.Getenv("DB_PASSWORD"),
+        DBname:   os.Getenv("DB_NAME"),
+        Host:     os.Getenv("DB_HOST"),
     }
-    
-    return &Config {
-        Logfile:    cfg.Section(section).Key("logfile").String(),
-        User:  cfg.Section(section).Key("user").String(),
-        Password: cfg.Section(section).Key("password").String(),
-        DBname: cfg.Section(section).Key("dbname").String(),
-    }, nil
 }

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -7,8 +7,7 @@ import(
     )
 
 func TestLoadConfig(t *testing.T){
-    cfg, err := LoadConfig("test")
-    assert.NoError(t,err,"config読込エラー %v", err)
+    cfg := LoadConfig()
     assert.NotEmpty(t, cfg.Logfile,"読込んだ結果が空です")
     fmt.Print(cfg)
 }

--- a/api/handlers/todoHandlers.go
+++ b/api/handlers/todoHandlers.go
@@ -102,7 +102,7 @@ func CreateTodo(w http.ResponseWriter, r *http.Request){
     }
     
     //todoの作成
-    err = user.CreateTodo(req.Content)
+    _, err = user.CreateTodo(req.Content)
     if err != nil{
         utils.JsonError(w, http.StatusInternalServerError, "todoの作成に失敗")
         return

--- a/api/models/base.go
+++ b/api/models/base.go
@@ -20,12 +20,13 @@ const(
 func InitDB (conf *config.Config) error {
     var err error
     user := conf.User
-    password :=conf.Password
+    password := conf.Password
     dbname := conf.DBname
-    connStr :=fmt.Sprintf("user=%s password=%s dbname=%s sslmode=disable", user, password, dbname)
-    DB , err = sql.Open("postgres", connStr)
-    
-    if err != nil{
+    host := conf.Host
+    connStr := fmt.Sprintf("host=%s user=%s password=%s dbname=%s sslmode=disable", host, user, password, dbname)
+    DB, err = sql.Open("postgres", connStr)
+
+    if err != nil {
         return fmt.Errorf("DB接続エラー %w", err)
     }
     

--- a/api/models/base_test.go
+++ b/api/models/base_test.go
@@ -9,8 +9,8 @@ import(
 
 func TestInitDB(t *testing.T){
     //configのテスト
-    cfg, err := config.LoadConfig("test")
-    assert.NoError(t, err, "LoadConfigでエラー発生")
+    cfg := config.LoadConfig()
+    assert.NotEmpty(t, cfg, "LoadConfigでデータが取得できない")
     //DBのイニシャライズ
     err = InitDB(cfg)
     assert.NoError(t, err, "InitDBでエラー発生")

--- a/api/models/todo.go
+++ b/api/models/todo.go
@@ -21,8 +21,11 @@ func (u *User)CreateTodo(content string)(*Todo, error){
         state,
         userid,
         createdat,
-        updatedat) values ($1,$2,$3,$4,$5) returning id, content, state, userid, createdat, updatedat`
-    if err := DB.QueryRow(cmd, content, "未着手", u.ID, time.Now(), time.Now()).Scan(
+        updatedat) values ($1,$2,$3,$4,$5) returning 
+        id, content, state, userid, createdat, updatedat`
+    // CreatedAtと UpdatedAtは同じ値を使う
+    saveTime := time.Now()
+    if err := DB.QueryRow(cmd, content, "未着手", u.ID, saveTime, saveTime).Scan(
         &todo.ID,
         &todo.Content,
         &todo.State,

--- a/api/router/router_test.go
+++ b/api/router/router_test.go
@@ -13,10 +13,9 @@ import(
 func TestGetTodosHandlar(t *testing.T){
     
     //test毎に初期化が必要なセット
-    cfg, err := config.LoadConfig("test")
-    if err != nil{
-        fmt.Println(err)
-        return
+    cfg := config.LoadConfig()
+    if cfg == nil {
+        t.Fatal("failed to load config: cfg is nil")
     }
     err = models.InitDB(cfg)
     if err != nil{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,21 +15,7 @@ services:
             #「db_data という名前付きボリュームを、コンテナ内の /var/lib/postgresql/data にマウントする」という意味
             - db_data:/var/lib/postgresql/data
     
-    web:
-        build:
-            context: ./web  #そのサービスのDockerイメージをビルドする際に「どのディレクトリをビルドコンテキストとして使うか」を指定する設定
-            dockerfile: Dockerfile  #上記context内のDockerfileを使用してイメージをビルドしてね
-        volumes:
-            #ホスト（あなたのPCやサーバー）側のルートディレクトリ直下にある「web」フォルダ（./web）
-            #とコンテナ内のルート直下にある「/app」ディレクトリを同期（バインドマウント）するという意味
-            - ./web:/app
-        ports:
-            #ホスト（あなたのPCやサーバ）の3000番ポートを、コンテナ内の3000番ポートにマッピングします。
-            #localhost:3000（ホスト側）にアクセスすると、コンテナ内の3000番ポートで待ち受けているWebサーバーにリクエストが転送されます。
-            - "3000:3000"
-        depends_on:
-            - api
-    
+
     api:
         image: golang:1.13
         working_dir: /go/src/app


### PR DESCRIPTION
Environment variables are now managed using a .env file instead of an ini file.
This change streamlines configuration and improves compatibility with Docker Compose.

環境変数の管理を.envに変更し、iniファイルの使用を終了
Dockerに対応し、設定しやすいようになります。